### PR TITLE
RAC-6429 build/release and unit test smi-lib-xxx repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
   dependencies {
  	classpath "io.spring.gradle:dependency-management-plugin:1.0.2.RELEASE"
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.15"
-    classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.2.1"
+    classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
     //classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
   }
@@ -67,8 +67,10 @@ task javadocJar(type: Jar) {
 repositories {
 	mavenLocal()
 	maven {
-	    url "${artifactory_contextUrl}/${dependency_repo}"
-	}
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://oss.sonatype.org/content/repositories/releases"
+        url "https://repo.maven.apache.org/maven2"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
**Background**
It's found that all the smi-lib-xxx repo can't be built with gradle. From the error log, the old version of sonarqube cannot work. So, the version of sonarqube needs to be upgraded.

**Reviewers**
@nortonluo @lanchongyizu @AlaricChan